### PR TITLE
Feat/auth: fix signUp email form async validation & complete signUp user flow

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import { Footer } from '@components/Footer';
 import { Navigation } from '@components/Navigation';
 import AuthProvider from '@components/Providers/AuthProvider';
 import '@styles/globals.css';
+import { Toaster } from 'react-hot-toast';
 
 const inter = Inter({ subsets: ['latin'], weight: ['400', '600', '700'] });
 
@@ -22,6 +23,15 @@ export default function RootLayout({
     <AuthProvider>
       <html lang="en" className="h-full">
         <body className={`${inter.className} h-full`}>
+          <Toaster
+            toastOptions={{
+              style: {
+                color: '#111827',
+                fontSize: '0.8rem',
+                backgroundColor: '#F9FAFB',
+              },
+            }}
+          />
           <Navigation />
           {children}
           <Footer />

--- a/components/Auth/SignUpForm.tsx
+++ b/components/Auth/SignUpForm.tsx
@@ -1,13 +1,16 @@
 'use client';
 
 import { Input, Label } from '@components/ui';
+import { FaceFrownIcon, FaceSmileIcon } from '@heroicons/react/20/solid';
 import { ErrorMessage } from '@hookform/error-message';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { debounce } from 'lodash';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { toast } from 'react-hot-toast';
 import * as yup from 'yup';
 
+import Modal from '@components/ui/Modal';
 import { asyncCacheTest } from '@lib/asyncCacheTest';
 
 // Override default email regex
@@ -85,6 +88,9 @@ export const signUpFormSchema = yup.object().shape({
 export type SignUpFormData = yup.InferType<typeof signUpFormSchema>;
 
 function SignUpForm() {
+  const [modalOpen, setModalOpen] = useState<boolean>(false);
+  const [isAccountCreated, setIsAccountCreated] = useState<boolean>(false);
+  const router = useRouter();
   const {
     register,
     handleSubmit,
@@ -98,10 +104,12 @@ function SignUpForm() {
       password: '',
       confirmPassword: '',
     },
+    mode: 'onChange',
   });
 
   const onSubmit = async (data: SignUpFormData) => {
     try {
+      setIsAccountCreated(false);
       const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/users`, {
         method: 'POST',
         headers: {
@@ -110,18 +118,23 @@ function SignUpForm() {
         body: JSON.stringify(data),
       });
 
+      // throw error with status code and message in the request response
       if (!res.ok) {
-        toast.error('Something went wrong, please try again later.');
+        setIsAccountCreated(false);
+        setModalOpen(true);
         throw {
           status: res.status,
-          message: 'Something went wrong',
+          message: 'Something went wrong, please try again later',
         };
       }
 
-      // toast.success('You have successfully signed up!');
       const user = await res.json();
+      setIsAccountCreated(true);
+      setModalOpen(true);
       return user;
     } catch (error) {
+      setIsAccountCreated(false);
+      setModalOpen(true);
       console.error(error);
     }
   };
@@ -140,122 +153,156 @@ function SignUpForm() {
   } = register('email');
 
   return (
-    <form className="space-y-6" onSubmit={handleSubmit(onSubmit)}>
-      <div>
-        <Label htmlFor="firstName" className="leading-6 text-gray-900">
-          First name
-        </Label>
-        <div className="mt-2">
-          <Input
-            id="firstName"
-            type="text"
-            autoComplete="given-name"
-            {...register('firstName')}
-            className="border-0 py-1.5 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset sm:leading-6"
-          />
-        </div>
-        <ErrorMessage
-          errors={errors}
-          name="firstName"
-          as="p"
-          className="text-sm font-medium text-red-500 mt-1 ml-1"
+    <>
+      {isAccountCreated ? (
+        <Modal
+          open={modalOpen}
+          setOpen={setModalOpen}
+          title="Account registration successful"
+          description="You have successfully registered your account. Please check your email to verify your account."
+          buttonText="Go to homepage"
+          svgIcon={
+            <FaceSmileIcon
+              className="h-6 w-6 text-green-600"
+              aria-hidden="true"
+            />
+          }
+          buttonAction={() => router.push('/')}
         />
-      </div>
-      <div>
-        <Label htmlFor="lastName" className="leading-6 text-gray-900">
-          Last name
-        </Label>
-        <div className="mt-2">
-          <Input
-            id="lastName"
-            type="text"
-            autoComplete="family-name"
-            {...register('lastName')}
-            className="border-0 py-1.5 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset sm:leading-6"
-          />
-        </div>
-        <ErrorMessage
-          errors={errors}
-          name="lastName"
-          as="p"
-          className="text-sm font-medium text-red-500 mt-1 ml-1"
+      ) : (
+        <Modal
+          open={modalOpen}
+          setOpen={setModalOpen}
+          title="Account registration failed"
+          description="Something went wrong, please try again later."
+          buttonText="Close"
+          svgIcon={
+            <FaceFrownIcon
+              className="h-6 w-6 text-red-600"
+              aria-hidden="true"
+            />
+          }
+          iconBgColor="bg-red-100"
         />
-      </div>
-      <div>
-        <Label htmlFor="email" className="leading-6 text-gray-900">
-          Email address
-        </Label>
-        <div className="mt-2">
-          <Input
-            id="email"
-            type="email"
-            autoComplete="email"
-            name={emailName}
-            ref={emailRef}
-            onChange={debounce(emailOnChange, 1000)}
-            onBlur={debounce(emailOnBlur, 1000)}
-            className="border-0 py-1.5 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset sm:leading-6"
-          />
-        </div>
-        <ErrorMessage
-          errors={errors}
-          name="email"
-          as="p"
-          className="text-sm font-medium text-red-500 mt-1 ml-1"
-        />
-      </div>
+      )}
 
-      <div>
-        <Label htmlFor="password" className="leading-6 text-gray-900">
-          Password
-        </Label>
-        <div className="mt-2">
-          <Input
-            id="password"
-            type="password"
-            autoComplete="current-password"
-            {...register('password')}
-            className="border-0 py-1.5 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset sm:leading-6"
+      <form className="space-y-6" onSubmit={handleSubmit(onSubmit)}>
+        <div>
+          <Label htmlFor="firstName" className="leading-6 text-gray-900">
+            First name
+          </Label>
+          <div className="mt-2">
+            <Input
+              id="firstName"
+              type="text"
+              autoComplete="given-name"
+              {...register('firstName')}
+              className="border-0 py-1.5 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset sm:leading-6"
+            />
+          </div>
+          <ErrorMessage
+            errors={errors}
+            name="firstName"
+            as="p"
+            className="text-sm font-medium text-red-500 mt-1 ml-1"
           />
         </div>
-        <ErrorMessage
-          errors={errors}
-          name="password"
-          as="p"
-          className="text-sm font-medium text-red-500 mt-1 ml-1"
-        />
-      </div>
-
-      <div>
-        <Label htmlFor="confirmPassword" className="leading-6 text-gray-900">
-          Confirm password
-        </Label>
-        <div className="mt-2">
-          <Input
-            id="confirmPassword"
-            type="password"
-            autoComplete="current-password"
-            {...register('confirmPassword')}
-            className="border-0 py-1.5 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset sm:leading-6"
+        <div>
+          <Label htmlFor="lastName" className="leading-6 text-gray-900">
+            Last name
+          </Label>
+          <div className="mt-2">
+            <Input
+              id="lastName"
+              type="text"
+              autoComplete="family-name"
+              {...register('lastName')}
+              className="border-0 py-1.5 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset sm:leading-6"
+            />
+          </div>
+          <ErrorMessage
+            errors={errors}
+            name="lastName"
+            as="p"
+            className="text-sm font-medium text-red-500 mt-1 ml-1"
           />
         </div>
-        <ErrorMessage
-          errors={errors}
-          name="confirmPassword"
-          as="p"
-          className="text-sm font-medium text-red-500 mt-1 ml-1"
-        />
-      </div>
+        <div>
+          <Label htmlFor="email" className="leading-6 text-gray-900">
+            Email address
+          </Label>
+          <div className="mt-2">
+            <Input
+              id="email"
+              type="email"
+              autoComplete="email"
+              name={emailName}
+              ref={emailRef}
+              onChange={debounce(emailOnChange, 1000)}
+              onBlur={emailOnBlur}
+              className="border-0 py-1.5 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset sm:leading-6"
+            />
+          </div>
+          <ErrorMessage
+            errors={errors}
+            name="email"
+            as="p"
+            className="text-sm font-medium text-red-500 mt-1 ml-1"
+          />
+        </div>
 
-      <div>
-        <button
-          type="submit"
-          className="flex w-full justify-center rounded-md bg-primary-500 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-primary-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
-        >
-          Create Account
-        </button>
-      </div>
-    </form>
+        <div>
+          <Label htmlFor="password" className="leading-6 text-gray-900">
+            Password
+          </Label>
+          <div className="mt-2">
+            <Input
+              id="password"
+              type="password"
+              autoComplete="current-password"
+              {...register('password')}
+              className="border-0 py-1.5 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset sm:leading-6"
+            />
+          </div>
+          <ErrorMessage
+            errors={errors}
+            name="password"
+            as="p"
+            className="text-sm font-medium text-red-500 mt-1 ml-1"
+          />
+        </div>
+
+        <div>
+          <Label htmlFor="confirmPassword" className="leading-6 text-gray-900">
+            Confirm password
+          </Label>
+          <div className="mt-2">
+            <Input
+              id="confirmPassword"
+              type="password"
+              autoComplete="current-password"
+              {...register('confirmPassword')}
+              className="border-0 py-1.5 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset sm:leading-6"
+            />
+          </div>
+          <ErrorMessage
+            errors={errors}
+            name="confirmPassword"
+            as="p"
+            className="text-sm font-medium text-red-500 mt-1 ml-1"
+          />
+        </div>
+
+        <div>
+          <button
+            type="submit"
+            className="flex w-full justify-center rounded-md bg-primary-500 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-primary-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+          >
+            Create Account
+          </button>
+        </div>
+      </form>
+    </>
   );
 }
 

--- a/components/Auth/SignUpFormSchema.ts
+++ b/components/Auth/SignUpFormSchema.ts
@@ -1,0 +1,65 @@
+import * as yup from 'yup';
+
+// Override default email regex
+yup.addMethod(yup.string, 'email', function validateEmail(message) {
+  return this.matches(/^[^\s@]+@[^\s@]+\.[^\s@]+$/, {
+    message,
+    excludeEmptyString: true,
+  });
+});
+
+export const signUpFormSchema = yup.object().shape({
+  firstName: yup
+    .string()
+    .required('Your first name is required')
+    .max(50, 'Your first name is too long'),
+  lastName: yup
+    .string()
+    .required('Your last name is required')
+    .max(50, 'Your last name is too long'),
+  // If the email validation fails inside the test method, it will throw validationError, which prevents calling the API in every keystroke (deboucing)
+  // source from this github issue: https://github.com/jquense/yup/issues/256
+  email: yup
+    .string()
+
+    .required('Your email is required')
+    .test('unique-email', 'This email is already registered', async (value) => {
+      try {
+        await yup
+          .object({
+            email: yup
+              .string()
+              .email('Invalid email address')
+              .required('Your email is required'),
+          })
+          .validate({ email: value });
+
+        const result = await fetch(
+          `${process.env.NEXT_PUBLIC_API_URL}/api/emailValidation/${value}`
+        );
+
+        return result.status === 200;
+      } catch (error) {
+        return false;
+      }
+    }),
+
+  // password must contain at least 8 characters, at least one uppercase letter, one lowercase letter, one number
+  password: yup
+    .string()
+    .required('Your password is required')
+    .min(8, 'Password must be at least 8 characters long')
+    .matches(
+      /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[a-zA-Z\d]{8,}$/,
+      'Password must contain at least one uppercase and lowercase letter, and one number'
+    ),
+  // confirm password must match password
+  confirmPassword: yup
+    .string()
+    .required('Please confirm your password')
+    .test('passwords-match', 'Passwords must match', function (value) {
+      return this.parent.password === value;
+    }),
+});
+
+export type SignUpFormData = yup.InferType<typeof signUpFormSchema>;

--- a/components/ui/Modal.tsx
+++ b/components/ui/Modal.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { Dialog, Transition } from '@headlessui/react';
+import { cn } from '@lib/classNames';
+import { Dispatch, Fragment, SetStateAction } from 'react';
+
+interface ModalProps {
+  open: boolean;
+  setOpen: Dispatch<SetStateAction<boolean>>;
+  svgIcon?: JSX.Element;
+  iconBgColor?: string;
+  title: string;
+  description?: string;
+  buttonText: string;
+  buttonAction?: () => void;
+}
+
+export default function Modal({
+  open,
+  setOpen,
+  svgIcon,
+  title,
+  description,
+  buttonText,
+  iconBgColor,
+  buttonAction,
+}: ModalProps) {
+  return (
+    <Transition.Root show={open} as={Fragment}>
+      <Dialog as="div" className="relative z-10" onClose={setOpen}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 z-10 overflow-y-auto">
+          <div className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+              enterTo="opacity-100 translate-y-0 sm:scale-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100 translate-y-0 sm:scale-100"
+              leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+            >
+              <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-sm sm:p-6">
+                <div>
+                  <div
+                    className={cn(
+                      'mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-green-100',
+                      iconBgColor
+                    )}
+                  >
+                    {svgIcon}
+                  </div>
+                  <div className="mt-3 text-center sm:mt-5">
+                    <Dialog.Title
+                      as="h3"
+                      className="text-base font-semibold leading-6 text-gray-900"
+                    >
+                      {title}
+                    </Dialog.Title>
+                    <div className="mt-2">
+                      <p className="text-sm text-gray-500">{description}</p>
+                    </div>
+                  </div>
+                </div>
+                <div className="mt-5 sm:mt-6">
+                  <button
+                    type="button"
+                    className="inline-flex w-full justify-center rounded-md bg-primary-500 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-primary-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+                    onClick={() => {
+                      setOpen(false);
+                      buttonAction && buttonAction();
+                    }}
+                  >
+                    {buttonText}
+                  </button>
+                </div>
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition.Root>
+  );
+}

--- a/lib/asyncCacheTest.ts
+++ b/lib/asyncCacheTest.ts
@@ -1,0 +1,18 @@
+// Ref: https://stackoverflow.com/questions/71806792/yup-run-async-validation-test-only-on-value-change
+// This is mainly implemented to prevent calling the API if the value is the same as the previous value
+export const asyncCacheTest = (
+  asyncValidate: (val: string) => Promise<boolean>
+) => {
+  let _valid = false;
+  let _value = '';
+
+  return async (value: string) => {
+    if (value !== _value) {
+      const response = await asyncValidate(value);
+      _value = value;
+      _valid = response as boolean;
+      return response as boolean;
+    }
+    return _valid;
+  };
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-hook-form": "^7.45.0",
+        "react-hot-toast": "^2.4.1",
         "react-icons": "^4.10.1",
         "react-redux": "^8.1.0",
         "tailwind-merge": "^1.13.2",
@@ -3082,6 +3083,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/goober": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.13.tgz",
+      "integrity": "sha512-jFj3BQeleOoy7t93E9rZ2de+ScC4lQICLwiAQmKMg9F6roKGaLSHoCDYKkWlSafg138jejvq/mTdvmnwDQgqoQ==",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -4742,6 +4751,21 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.4.1.tgz",
+      "integrity": "sha512-j8z+cQbWIM5LY37pR6uZR6D4LfseplqnuAO4co4u8917hBUvXlEqyP1ZzqVLcqoyUesZZv/ImreoCeHVDpE5pQ==",
+      "dependencies": {
+        "goober": "^2.1.10"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-icons": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-hook-form": "^7.45.0",
+    "react-hot-toast": "^2.4.1",
     "react-icons": "^4.10.1",
     "react-redux": "^8.1.0",
     "tailwind-merge": "^1.13.2",

--- a/prisma/migrations/20230713003025_update_user_model/migration.sql
+++ b/prisma/migrations/20230713003025_update_user_model/migration.sql
@@ -1,0 +1,10 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `firstName` on the `User` table. All the data in the column will be lost.
+  - You are about to drop the column `lastName` on the `User` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "User" DROP COLUMN "firstName",
+DROP COLUMN "lastName";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,8 +9,6 @@ datasource db {
 
 model User {
   id            String    @id @default(cuid())
-  firstName     String?
-  lastName      String?
   name          String?
   email         String    @unique
   emailVerified DateTime?

--- a/yarn.lock
+++ b/yarn.lock
@@ -1052,7 +1052,7 @@ cssesc@^3.0.0:
   resolved "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
 
-csstype@^3.0.2:
+csstype@^3.0.10, csstype@^3.0.2:
   version "3.1.2"
   resolved "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz"
   integrity sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==
@@ -1761,6 +1761,11 @@ globby@^13.1.3:
     ignore "^5.2.0"
     merge2 "^1.4.1"
     slash "^4.0.0"
+
+goober@^2.1.10:
+  version "2.1.13"
+  resolved "https://registry.npmjs.org/goober/-/goober-2.1.13.tgz"
+  integrity sha512-jFj3BQeleOoy7t93E9rZ2de+ScC4lQICLwiAQmKMg9F6roKGaLSHoCDYKkWlSafg138jejvq/mTdvmnwDQgqoQ==
 
 gopd@^1.0.1:
   version "1.0.1"
@@ -2779,7 +2784,7 @@ queue-microtask@^1.2.2:
   resolved "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
-"react-dom@^16 || ^17 || ^18", "react-dom@^16.8 || ^17.0 || ^18.0", "react-dom@^17.0.2 || ^18", react-dom@^18.2.0, react-dom@>=16.8.0, react-dom@18.2.0:
+"react-dom@^16 || ^17 || ^18", "react-dom@^16.8 || ^17.0 || ^18.0", "react-dom@^17.0.2 || ^18", react-dom@^18.2.0, react-dom@>=16, react-dom@>=16.8.0, react-dom@18.2.0:
   version "18.2.0"
   resolved "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz"
   integrity sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==
@@ -2791,6 +2796,13 @@ react-hook-form@^7.0.0, react-hook-form@^7.45.0:
   version "7.45.0"
   resolved "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.45.0.tgz"
   integrity sha512-AbHeZ4ad+0dEIknSW9dBgIwcvRDfZ1O97sgj75WaMdOX0eg8TBiUf9wxzVkIjZbk76BBIE9lmFOzyD4PN80ZQg==
+
+react-hot-toast@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.4.1.tgz"
+  integrity sha512-j8z+cQbWIM5LY37pR6uZR6D4LfseplqnuAO4co4u8917hBUvXlEqyP1ZzqVLcqoyUesZZv/ImreoCeHVDpE5pQ==
+  dependencies:
+    goober "^2.1.10"
 
 react-icons@^4.10.1:
   version "4.10.1"
@@ -2847,7 +2859,7 @@ react-style-singleton@^2.2.1:
     invariant "^2.2.4"
     tslib "^2.0.0"
 
-react@*, "react@^16 || ^17 || ^18", "react@^16.8 || ^17.0 || ^18.0", "react@^16.8.0 || ^17 || ^18", "react@^16.8.0 || ^17.0.0 || ^18.0.0", "react@^16.9.0 || ^17.0.0 || ^18", "react@^17.0.2 || ^18", react@^18.2.0, "react@>= 16", "react@>= 16.8.0 || 17.x.x || ^18.0.0-0", react@>=16.8.0, react@18.2.0:
+react@*, "react@^16 || ^17 || ^18", "react@^16.8 || ^17.0 || ^18.0", "react@^16.8.0 || ^17 || ^18", "react@^16.8.0 || ^17.0.0 || ^18.0.0", "react@^16.9.0 || ^17.0.0 || ^18", "react@^17.0.2 || ^18", react@^18.2.0, "react@>= 16", "react@>= 16.8.0 || 17.x.x || ^18.0.0-0", react@>=16, react@>=16.8.0, react@18.2.0:
   version "18.2.0"
   resolved "https://registry.npmjs.org/react/-/react-18.2.0.tgz"
   integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==


### PR DESCRIPTION
The signUp email form async validation is now debounced and will cache previous error result in order to prevent unnecessary api calls. The async validation will only be called when a valid email is already registered or is a valid email but user keeps typing.

Also, the form submission is added the success/error modal to notify users what is happening. If it's successful, it will redirect users to homepage when modal is closed. If it's failed, it will notify users and users will stay on the same page when modal is closed.