### PR TITLE
Feat/auth: implement email verification token regeneration when expired

### DIFF
--- a/app/api/emailValidation/tokenVerification/[token]/route.ts
+++ b/app/api/emailValidation/tokenVerification/[token]/route.ts
@@ -37,6 +37,7 @@ export async function GET(
         status: 400,
         message: 'Token has expired',
         data: {
+          email,
           emailVerifyToken: token,
           emailVerified: false,
           emailTokenExpired: true,
@@ -57,6 +58,7 @@ export async function GET(
         status: 400,
         message: 'Email is already verified',
         data: {
+          email,
           emailVerifyToken: userWithRegisteredEmail.emailVerifyToken,
           emailVerified: true,
           emailTokenExpired: false,
@@ -72,12 +74,16 @@ export async function GET(
       userWithRegisteredEmail.emailVerifyToken
     );
 
-    if (decodedPayload?.email === email) {
+    if (
+      decodedPayload?.email === email &&
+      userWithRegisteredEmail?.emailVerifyToken === token
+    ) {
       return NextResponse.json(
         {
           status: 200,
           message: 'Email is verified',
           data: {
+            email,
             emailVerifyToken: userWithRegisteredEmail.emailVerifyToken,
             emailVerified: true,
             emailTokenExpired: false,
@@ -93,8 +99,9 @@ export async function GET(
       return NextResponse.json(
         {
           status: 400,
-          message: 'Email is not verified',
+          message: 'Email Verification Token is invalid',
           data: {
+            email,
             emailVerifyToken: userWithRegisteredEmail.emailVerifyToken,
             emailVerified: false,
             emailTokenExpired: false,
@@ -110,6 +117,7 @@ export async function GET(
         status: 400,
         message: 'Email Verification Token is not found',
         data: {
+          email,
           emailVerifyToken: userWithRegisteredEmail?.emailVerifyToken,
           emailVerified: false,
           emailTokenExpired: false,

--- a/app/api/sendEmail/route.ts
+++ b/app/api/sendEmail/route.ts
@@ -1,0 +1,60 @@
+import { transporter } from '@lib/emailTransporter';
+import { NextResponse } from 'next/server';
+
+interface emailPayload {
+  firstName: string;
+  email: string;
+  emailVerificationToken: string;
+}
+
+export async function POST(req: Request, res: Response) {
+  const body: emailPayload = await req.json();
+  const { firstName, email, emailVerificationToken } = body;
+  try {
+    if (!email) {
+      return NextResponse.json({
+        success: false,
+        data: null,
+        status: 401,
+        error: 'ValidationError',
+        message: 'Email is not supplied',
+      });
+    }
+
+    if (!emailVerificationToken) {
+      return NextResponse.json({
+        success: false,
+        data: null,
+        status: 401,
+        error: 'ValidationError',
+        message: 'Email verification token is not supplied',
+      });
+    }
+
+    await transporter.sendMail({
+      from: process.env.EMAIL_FROM,
+      to: email,
+      subject: 'Verify your email address',
+      html: `
+      <div>
+        <h1>Verify your email address</h1>
+        <p>Hi ${firstName},</p>
+        <p>Thanks for signing up for an account on <a href=${process.env.APP_BASE_URL}>Blossom Lane</a>.</p>
+        <p>Please click the link below to verify your email address:</p>
+        <a href="${process.env.APP_BASE_URL}/verify-email?token=${emailVerificationToken}">Verify your email address</a>
+        <p>Thanks,</p>
+        <p>Blossom Lane Team</p>
+      </div>
+    `,
+    });
+
+    return NextResponse.json({
+      success: true,
+      data: null,
+      status: 201,
+      message: 'Email Verification Link is sent successfully',
+    });
+  } catch (error) {
+    console.log(error);
+  }
+}

--- a/components/Auth/SignUpForm.tsx
+++ b/components/Auth/SignUpForm.tsx
@@ -183,6 +183,7 @@ function SignUpForm() {
             />
           }
           buttonAction={() => router.push('/')}
+          backdropAction={() => router.push('/')}
         />
       ) : (
         <Modal

--- a/components/ui/Modal.tsx
+++ b/components/ui/Modal.tsx
@@ -13,6 +13,7 @@ interface ModalProps {
   description?: string;
   buttonText: string;
   buttonAction?: () => void;
+  backdropAction?: () => void;
 }
 
 export default function Modal({
@@ -24,6 +25,7 @@ export default function Modal({
   buttonText,
   iconBgColor,
   buttonAction,
+  backdropAction,
 }: ModalProps) {
   return (
     <Transition.Root show={open} as={Fragment}>
@@ -32,7 +34,7 @@ export default function Modal({
         className="relative z-10"
         onClose={() => {
           setOpen(false);
-          buttonAction && buttonAction();
+          backdropAction && backdropAction();
         }}
       >
         <Transition.Child

--- a/lib/jwt.ts
+++ b/lib/jwt.ts
@@ -12,7 +12,7 @@ export function signJwtAccessToken(
   payload: JwtPayload,
   options: SignOptions = DEFAULT_SIGN_OPTIONS
 ) {
-  const secret = process.env.JWT_SECRET;
+  const secret = process.env.JWT_SECRET || process.env.NEXT_PUBLIC_JWT_SECRET;
 
   if (!secret) {
     throw new Error('Missing JWT_SECRET env variable');

--- a/lib/sendNewEmailVerificationLink.ts
+++ b/lib/sendNewEmailVerificationLink.ts
@@ -1,0 +1,74 @@
+import { signJwtAccessToken, verifyJwtAccessToken } from './jwt';
+
+export interface sendNewEmailVerificationLinkProps {
+  emailVerificationToken: string | null;
+  setEmailVerificationToken: (token: string) => void;
+  setIsEmailTokenExpired: (isExpired: boolean) => void;
+}
+
+export const sendNewEmailVerificationLink = async ({
+  emailVerificationToken,
+  setEmailVerificationToken,
+  setIsEmailTokenExpired,
+}: sendNewEmailVerificationLinkProps) => {
+  // generate new email verification token
+  try {
+    if (!emailVerificationToken) {
+      return false;
+    }
+
+    const { email, firstName, lastName } = verifyJwtAccessToken(
+      emailVerificationToken
+    ) as { email: string; firstName: string; lastName: string };
+
+    const newEmailVerifyToken = signJwtAccessToken({
+      email,
+      firstName,
+      lastName,
+    });
+
+    setEmailVerificationToken(newEmailVerifyToken);
+
+    // save new email verification token to db
+    const newEmailVerifyTokenResult = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL}/api/users`,
+      {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          email: email,
+          emailVerifyToken: newEmailVerifyToken,
+        }),
+      }
+    );
+
+    const newEmailVerifyTokenData = await newEmailVerifyTokenResult.json();
+    console.log('newEmailVerifyTokenData: ', newEmailVerifyTokenData);
+
+    if (newEmailVerifyTokenData?.status === 201) {
+      try {
+        await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/sendEmail`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            email: email,
+            emailVerificationToken: newEmailVerifyToken,
+            firstName: firstName + 'new',
+          }),
+        });
+
+        setIsEmailTokenExpired(false);
+        return true;
+      } catch (error) {
+        console.error(error);
+        return false;
+      }
+    }
+  } catch (error) {
+    console.error(error);
+  }
+};


### PR DESCRIPTION
If the email verification token is expired, it will ask users to send a new verification email to their designated email address and go through email verification token validation flow again. Then the new verification token will be saved in db as well as updating email_verified.