### PR TITLE
Feat/auth: error handling to refresh access token when verifying access token is expired

### DIFF
--- a/app/api/emailValidation/tokenVerification/[token]/route.ts
+++ b/app/api/emailValidation/tokenVerification/[token]/route.ts
@@ -25,8 +25,24 @@ export async function GET(
     );
   }
 
-  // check if token had expired 2 days after it was issued
   const decodedToken = verifyJwtAccessToken(token);
+
+  if (!decodedToken) {
+    return NextResponse.json(
+      {
+        status: 400,
+        message: 'Something went wrong with verifying access token',
+        data: {
+          emailVerifyToken: token,
+          emailVerified: false,
+          emailTokenExpired: true,
+        },
+        error: 'ValidationError',
+      },
+      { status: 400, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+
   const { email, exp } = decodedToken as Payload;
   const expiresAt = new Date(exp! * 1000);
   const isExpired = new Date() > expiresAt;

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -94,11 +94,16 @@ export async function POST(req: Request, res: Response) {
   const hashedPassword = await bcrypt.hash(password, 10);
 
   // Generate emailVerificationToken and will be saved in db
-  const emailVerificationToken = signJwtAccessToken({
-    email,
-    firstName,
-    lastName,
-  });
+  const emailVerificationToken = signJwtAccessToken(
+    {
+      email,
+      firstName,
+      lastName,
+    },
+    {
+      expiresIn: '1d',
+    }
+  );
 
   // create user in database
   const user = await prisma.user.create({

--- a/app/verify-email/page.tsx
+++ b/app/verify-email/page.tsx
@@ -3,7 +3,7 @@
 import { CheckIcon, FaceFrownIcon } from '@heroicons/react/20/solid';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useState } from 'react';
-import toast, { useToasterStore } from 'react-hot-toast';
+import toast from 'react-hot-toast';
 
 import Modal from '@components/ui/Modal';
 import { sendNewEmailVerificationLink } from '@lib/sendNewEmailVerificationLink';
@@ -24,16 +24,12 @@ export default function VerifyEmailPage() {
   const searchParam = useSearchParams();
   const router = useRouter();
   const token = searchParam.get('token');
-  const [isEmailTokenExpired, setIsEmailTokenExpired] =
-    useState<boolean>(false);
   const [modalOpen, setModalOpen] = useState<boolean>(false);
   const [emailVerificationToken, setEmailVerificationToken] = useState<
     string | null
   >(null);
   const [isEmailVerified, setIsEmailVerified] = useState<boolean>(false);
   const [ErrorMessage, setErrorMessage] = useState<string>('');
-
-  const { toasts, pausedAt } = useToasterStore();
 
   const handleVerifyEmail = async (token: string | null) => {
     try {
@@ -50,7 +46,6 @@ export default function VerifyEmailPage() {
       if (emailVerifyToken) setEmailVerificationToken(emailVerifyToken);
 
       if (emailTokenExpired) {
-        // setIsEmailTokenExpired(true);
         setModalOpen(true);
         setIsEmailVerified(false);
         setErrorMessage('Email verification token has expired');
@@ -104,15 +99,13 @@ export default function VerifyEmailPage() {
 
   const handleSendNewEmailVerificationLink = async (
     emailVerificationToken: string | null,
-    setEmailVerificationToken: (token: string) => void,
-    setIsEmailTokenExpired: (isExpired: boolean) => void
+    setEmailVerificationToken: (token: string) => void
   ) => {
     // when it's clicked, send a new email verification link to the user's email
     toast.promise(
       sendNewEmailVerificationLink({
         emailVerificationToken,
         setEmailVerificationToken,
-        setIsEmailTokenExpired,
       }),
       {
         loading: 'Sending new email verification link...',
@@ -163,8 +156,8 @@ export default function VerifyEmailPage() {
               : () => {
                   handleSendNewEmailVerificationLink(
                     emailVerificationToken,
-                    setEmailVerificationToken,
-                    setIsEmailTokenExpired
+                    setEmailVerificationToken
+                    // setIsEmailTokenExpired
                   );
                 }
           }

--- a/components/Auth/SignUpFormSchema.ts
+++ b/components/Auth/SignUpFormSchema.ts
@@ -21,7 +21,6 @@ export const signUpFormSchema = yup.object().shape({
   // source from this github issue: https://github.com/jquense/yup/issues/256
   email: yup
     .string()
-
     .required('Your email is required')
     .test('unique-email', 'This email is already registered', async (value) => {
       try {

--- a/hooks/useAxiosAuth.ts
+++ b/hooks/useAxiosAuth.ts
@@ -1,0 +1,49 @@
+'use client';
+
+import { useSession } from 'next-auth/react';
+import { useEffect } from 'react';
+
+import { axiosWithAuth } from '@lib/axios';
+import useRefreshToken from './useRefreshToken';
+
+export default function useAxiosAuth() {
+  const { data: session } = useSession();
+  const refreshToken = useRefreshToken();
+
+  useEffect(() => {
+    // Add a request interceptor to add the access token to the request
+    const requestInterceptor = axiosWithAuth.interceptors.request.use(
+      (config) => {
+        if (!config.headers.Authorization) {
+          config.headers.Authorization = `Bearer ${session?.user.accessToken}`;
+        }
+        return config;
+      },
+      (error) => Promise.reject(error)
+    );
+
+    // Add a response interceptor to refresh the access token if it's expired
+    const responseInterceptor = axiosWithAuth.interceptors.response.use(
+      (response) => response,
+      async (error) => {
+        const prevRequest = error.config;
+        if (error.response.status === 401 && !prevRequest.sent) {
+          prevRequest.sent = true;
+          await refreshToken();
+          prevRequest.headers.Authorization = `Bearer ${session?.user.accessToken}`;
+          return axiosWithAuth(prevRequest);
+        }
+
+        return Promise.reject(error);
+      }
+    );
+
+    // Remove the request & response interceptors on unmount
+    return () => {
+      axiosWithAuth.interceptors.request.eject(requestInterceptor);
+      axiosWithAuth.interceptors.response.eject(responseInterceptor);
+    };
+  }, [session, refreshToken]);
+
+  return axiosWithAuth;
+}

--- a/hooks/useRefreshToken.ts
+++ b/hooks/useRefreshToken.ts
@@ -1,0 +1,28 @@
+'use client';
+
+import { useSession } from 'next-auth/react';
+
+export default function useRefreshToken() {
+  const { data: session } = useSession();
+
+  const refreshToken = async () => {
+    const response = await fetch(
+      `${process.env.NEXTAUTH_URL}/api/auth/refresh-token`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          refreshToken: session?.user.refreshToken,
+        }),
+      }
+    );
+
+    const data = await response.json();
+
+    if (session) session.user.accessToken = data.accessToken;
+  };
+
+  return refreshToken;
+}

--- a/lib/axios.ts
+++ b/lib/axios.ts
@@ -1,0 +1,17 @@
+import axios from 'axios';
+
+const BASE_URL = process.env.APP_BASE_URL || 'http://localhost:3000';
+
+export default axios.create({
+  baseURL: BASE_URL,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+export const axiosWithAuth = axios.create({
+  baseURL: BASE_URL,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});

--- a/lib/sendNewEmailVerificationLink.ts
+++ b/lib/sendNewEmailVerificationLink.ts
@@ -3,13 +3,11 @@ import { signJwtAccessToken, verifyJwtAccessToken } from './jwt';
 export interface sendNewEmailVerificationLinkProps {
   emailVerificationToken: string | null;
   setEmailVerificationToken: (token: string) => void;
-  setIsEmailTokenExpired: (isExpired: boolean) => void;
 }
 
 export const sendNewEmailVerificationLink = async ({
   emailVerificationToken,
   setEmailVerificationToken,
-  setIsEmailTokenExpired,
 }: sendNewEmailVerificationLinkProps) => {
   // generate new email verification token
   try {
@@ -60,7 +58,6 @@ export const sendNewEmailVerificationLink = async ({
           }),
         });
 
-        setIsEmailTokenExpired(false);
         return true;
       } catch (error) {
         console.error(error);

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@types/react": "18.2.12",
         "@types/react-dom": "18.2.5",
         "autoprefixer": "10.4.14",
+        "axios": "^1.4.0",
         "bcrypt": "^5.1.0",
         "clsx": "^1.2.1",
         "eslint": "8.43.0",
@@ -1623,6 +1624,11 @@
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
       "integrity": "sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag=="
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.14",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.14.tgz",
@@ -1672,6 +1678,16 @@
       "integrity": "sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -1952,6 +1968,17 @@
         "color-support": "bin.js"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -2095,6 +2122,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/delegates": {
@@ -2844,12 +2879,44 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
       "dependencies": {
         "is-callable": "^1.1.3"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fraction.js": {
@@ -3904,6 +3971,25 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/mimic-fn": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
@@ -4740,6 +4826,11 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.5.tgz",
       "integrity": "sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA=="
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/punycode": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@types/react": "18.2.12",
     "@types/react-dom": "18.2.5",
     "autoprefixer": "10.4.14",
+    "axios": "^1.4.0",
     "bcrypt": "^5.1.0",
     "clsx": "^1.2.1",
     "eslint": "8.43.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -839,6 +839,11 @@ ast-types-flow@^0.0.7:
   resolved "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz"
   integrity sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
 autoprefixer@10.4.14:
   version "10.4.14"
   resolved "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.14.tgz"
@@ -860,6 +865,15 @@ axe-core@^4.6.2:
   version "4.7.2"
   resolved "https://registry.npmjs.org/axe-core/-/axe-core-4.7.2.tgz"
   integrity sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g==
+
+axios@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz"
+  integrity sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==
+  dependencies:
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 axobject-query@^3.1.1:
   version "3.2.1"
@@ -1020,6 +1034,13 @@ color-support@^1.1.2:
   resolved "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz"
   integrity sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 commander@^4.0.0:
   version "4.1.1"
   resolved "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz"
@@ -1118,6 +1139,11 @@ define-properties@^1.1.3, define-properties@^1.1.4, define-properties@^1.2.0:
   dependencies:
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 delegates@^1.0.0:
   version "1.0.0"
@@ -1583,12 +1609,26 @@ flatted@^3.1.0:
   resolved "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
+follow-redirects@^1.15.0:
+  version "1.15.2"
+  resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz"
+  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
+
 for-each@^0.3.3:
   version "0.3.3"
   resolved "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz"
   integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
   dependencies:
     is-callable "^1.1.3"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 fraction.js@^4.2.0:
   version "4.2.0"
@@ -2300,6 +2340,18 @@ micromatch@^4.0.4, micromatch@^4.0.5:
     braces "^3.0.2"
     picomatch "^2.3.1"
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.12:
+  version "2.1.35"
+  resolved "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
 mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz"
@@ -2816,6 +2868,11 @@ property-expr@^2.0.5:
   version "2.0.5"
   resolved "https://registry.npmjs.org/property-expr/-/property-expr-2.0.5.tgz"
   integrity sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA==
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 punycode@^2.1.0:
   version "2.3.0"


### PR DESCRIPTION
When the app is verifying access token, it will throw errors right away when it is expired. To prevent this issue, the refresh access token mechanism is implemented. It validates if access token is expired, then refresh it and validate again. If it fails again, then throw errors that are not the TokenExpiredError.